### PR TITLE
.pre-commit-config.yaml: Limit terragrunt validate to folders with terragrunt.hcl files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,8 @@ repos:
   hooks:
     - id: terragrunt_fmt
     - id: terragrunt_validate
-      files: ^environments/.*/.*/terragrunt.hcl$
+      files: terragrunt.hcl
+      exclude: ^root.hcl
     - id: terraform_tflint
       args:
         - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,8 @@ repos:
   hooks:
     - id: terragrunt_fmt
     - id: terragrunt_validate
+      files: ^environments/.*/.*/terragrunt.hcl$
     - id: terraform_tflint
       args:
-        - --args=--config=__GIT_WORKING_DIR__.tflint.hcl
+        - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
       exclude: '/code_snippets/.*'

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ This is a template containing a basic skeleton for infrastructure as code projec
 
 Root modules that are holding state are stored in one of the environments. The environments `global`, `staging` and `production` are a good starting point.
 
-## Create own Modules
+## Create your own Modules
 
-See `environment/global/state-storage` for an example of an module.
+See `environment/global/state-storage` for an example of a module.
 
 ## Hierarchical loading of data
+
+The basic logic for data loading is defined in the `root.hcl` in the `environments` folder. This file gets included in every subsequent `terragrunt.hcl`. When running `terragrunt run-all plan` in the `environments` folder every `terragrunt.hcl` gets identified by Terragrunt as root module and a plan is created for every root module. This also explains why the top-level Terragrunt file must be named `root.hcl` instead of `terragrunt.hcl`. With this naming scheme Terragrunt doesn't identify `root.hcl` as a root module and won't create a plan for it, which would lead to an error.
+
+The `terragrunt.hcl` itself includes the `root.hcl` and all other relevant files. These two files combined lead to the following hierarchical loading logic:
 
 - module loads `inputs.yaml`
 - environment loads `environment_inputs.yaml`


### PR DESCRIPTION
I ran into the issue, that freshly checked out, the pre-commit configuration failed with this already known issue for me:

```
🛰️ ❯ pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
mixed line ending........................................................Passed
Terragrunt fmt...........................................................Passed
Terragrunt validate......................................................Failed
- hook id: terragrunt_validate
- exit code: 1

19:57:52.689 ERROR  stat ./terragrunt.hcl: no such file or directory
19:57:52.689 ERROR  Unable to determine underlying exit code, so Terragrunt will exit with error code 1
```

It appears to me that if you give any directory without a `terragrunt.hcl` file to `terragrunt_validate` this error occurs.

The issue seems to stem from the fact that there apparently needs to be a `terragrunt.hcl` file everywhere (although in https://github.com/antonbabenko/pre-commit-terraform/issues/191 it already looks like it should only run where a `.hcl` file exists.

Additionally please look at [this comment in the same issue](https://github.com/antonbabenko/pre-commit-terraform/issues/191#issuecomment-1446450064) where it seems like `root.hcl` is a bad name if we want the file to be validated.

I used the versions in this repo and also the newest ones available (`5.0.0` and `1.96.1` respectively) with not difference in behaviour.

This MR appears to me not as the best solution, but maybe its a solution to get pre-commit to cleanly run through?